### PR TITLE
feat: Allow public constants to be configured within a package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.idea/
 /.yardoc
 /_yardoc/
 /coverage/

--- a/lib/packwerk/application_validator/check_package_manifests_for_privacy.rb
+++ b/lib/packwerk/application_validator/check_package_manifests_for_privacy.rb
@@ -47,7 +47,7 @@ module Packwerk
 
         sig { returns(T::Array[String]) }
         def permitted_keys
-          ["public_path", "enforce_privacy"]
+          ["public_path", "enforce_privacy", "public_constants"]
         end
 
         private

--- a/lib/packwerk/package.rb
+++ b/lib/packwerk/package.rb
@@ -51,6 +51,11 @@ module Packwerk
       privacy_protected_package.enforce_privacy
     end
 
+    sig { returns(T::Array[String]) }
+    def public_constants
+      @config["public_constants"] || []
+    end
+
     sig { returns(String) }
     def public_path
       privacy_protected_package.public_path

--- a/lib/packwerk/reference_checking/checkers/privacy_checker.rb
+++ b/lib/packwerk/reference_checking/checkers/privacy_checker.rb
@@ -50,7 +50,8 @@ module Packwerk
 
           message = <<~EOS
             Privacy violation: '#{reference.constant.name}' is private to '#{reference.constant.package}' but referenced from #{source_desc}.
-            Is there a public entrypoint in '#{reference.constant.package.public_path}' that you can use instead?
+            Is there a public entrypoint from any of the following constants that you can use instead?
+            --> '#{reference.constant.package.public_constants.join(', ')}'
 
             #{standard_help_message(reference)}
           EOS

--- a/lib/packwerk/reference_checking/checkers/privacy_checker.rb
+++ b/lib/packwerk/reference_checking/checkers/privacy_checker.rb
@@ -33,6 +33,10 @@ module Packwerk
           return false unless privacy_option == true ||
             explicitly_private_constant?(reference.constant, explicitly_private_constants: privacy_option)
 
+          return false if explicitly_public_constant?(
+            reference.constant, explicitly_public_constants: reference.constant.package.public_constants
+          )
+
           true
         end
 
@@ -55,6 +59,16 @@ module Packwerk
         end
 
         private
+
+        sig do
+          params(
+            constant: ConstantDiscovery::ConstantContext,
+            explicitly_public_constants: T::Array[String]
+          ).returns(T::Boolean)
+        end
+        def explicitly_public_constant?(constant, explicitly_public_constants:)
+          explicitly_public_constants.include?(constant.name)
+        end
 
         sig do
           params(

--- a/test/unit/privacy_checker_test.rb
+++ b/test/unit/privacy_checker_test.rb
@@ -73,6 +73,17 @@ module Packwerk
       checker.invalid_reference?(reference)
     end
 
+    test "ignores explicitly configured public constant even if enforcing privacy for everything" do
+      destination_package = Package.new(
+        name: "destination_package",
+        config: { "enforce_privacy" => true, "public_constants" => ["::SomeName"] },
+      )
+      checker = privacy_checker
+      reference = build_reference(destination_package: destination_package, constant_name: "::SomeName")
+
+      refute checker.invalid_reference?(reference)
+    end
+
     private
 
     def privacy_checker


### PR DESCRIPTION
Packwerk only allows explicit _private_ constants to be configured, or a public directory within which public interfaces/constants live. This pushes packwerk more towards a world where we can test for privacy violations within `app/services` under our current public/private assumptions.