### PR TITLE
feat: Add support for configuring a reference collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@
 /.bundle/
 /tmp/
 .rubocop-*
+.idea
 .byebug_history
 sorbet/rbi/hidden-definitions/errors.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.idea/
 /.yardoc
 /_yardoc/
 /coverage/
@@ -9,6 +10,5 @@
 /.bundle/
 /tmp/
 .rubocop-*
-.idea
 .byebug_history
 sorbet/rbi/hidden-definitions/errors.txt

--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -32,6 +32,7 @@ module Packwerk
   autoload :NodeProcessor
   autoload :NodeProcessorFactory
   autoload :NodeVisitor
+  autoload :NoOpReferenceCollector
   autoload :Offense
   autoload :OffensesFormatter
   autoload :OutputStyle
@@ -43,6 +44,7 @@ module Packwerk
   autoload :UnresolvedReference
   autoload :Reference
   autoload :ReferenceExtractor
+  autoload :ReferenceCollector
   autoload :ReferenceOffense
   autoload :Result
   autoload :RunContext

--- a/lib/packwerk/no_op_reference_collector.rb
+++ b/lib/packwerk/no_op_reference_collector.rb
@@ -1,0 +1,14 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Packwerk
+  class NoOpReferenceCollector < ReferenceCollector
+    extend T::Sig
+
+    sig { override.params(reference: Reference, violation_type: String).void }
+    def collect_invalid(reference:, violation_type:); end
+
+    sig { override.params(reference: Reference, violation_type: String).void }
+    def collect_valid(reference:, violation_type:); end
+  end
+end

--- a/lib/packwerk/no_op_reference_collector.rb
+++ b/lib/packwerk/no_op_reference_collector.rb
@@ -5,10 +5,7 @@ module Packwerk
   class NoOpReferenceCollector < ReferenceCollector
     extend T::Sig
 
-    sig { override.params(reference: Reference, violation_type: String).void }
-    def collect_invalid(reference:, violation_type:); end
-
-    sig { override.params(reference: Reference, violation_type: String).void }
-    def collect_valid(reference:, violation_type:); end
+    sig { override.params(reference: Reference, violation_type: String, valid: T::Boolean).void }
+    def collect_reference(reference:, violation_type:, valid:); end
   end
 end

--- a/lib/packwerk/reference_checking/reference_checker.rb
+++ b/lib/packwerk/reference_checking/reference_checker.rb
@@ -20,7 +20,11 @@ module Packwerk
       def call(reference)
         @checkers.each_with_object([]) do |checker, violations|
           invalid_reference = checker.invalid_reference?(reference)
-          collect_reference(reference, invalid_reference, checker)
+          @reference_collector.collect_reference(
+            reference: reference,
+            violation_type: checker.violation_type,
+            valid: !invalid_reference,
+          )
 
           next unless invalid_reference
 
@@ -31,23 +35,6 @@ module Packwerk
             message: checker.message(reference)
           )
           violations << offense
-        end
-      end
-
-      private
-
-      sig do
-        params(
-          reference: Reference,
-          invalid_reference: T::Boolean,
-          checker: Checkers::Checker,
-        ).void
-      end
-      def collect_reference(reference, invalid_reference, checker)
-        if invalid_reference
-          @reference_collector.collect_invalid(reference: reference, violation_type: checker.violation_type)
-        else
-          @reference_collector.collect_valid(reference: reference, violation_type: checker.violation_type)
         end
       end
     end

--- a/lib/packwerk/reference_checking/reference_checker.rb
+++ b/lib/packwerk/reference_checking/reference_checker.rb
@@ -6,9 +6,10 @@ module Packwerk
     class ReferenceChecker
       extend T::Sig
 
-      sig { params(checkers: T::Array[Checkers::Checker]).void }
-      def initialize(checkers)
+      sig { params(checkers: T::Array[Checkers::Checker], reference_collector: ReferenceCollector).void }
+      def initialize(checkers, reference_collector = NoOpReferenceCollector.new)
         @checkers = checkers
+        @reference_collector = reference_collector
       end
 
       sig do
@@ -18,7 +19,10 @@ module Packwerk
       end
       def call(reference)
         @checkers.each_with_object([]) do |checker, violations|
-          next unless checker.invalid_reference?(reference)
+          invalid_reference = checker.invalid_reference?(reference)
+          collect_reference(reference, invalid_reference, checker)
+
+          next unless invalid_reference
 
           offense = Packwerk::ReferenceOffense.new(
             location: reference.source_location,
@@ -27,6 +31,23 @@ module Packwerk
             message: checker.message(reference)
           )
           violations << offense
+        end
+      end
+
+      private
+
+      sig do
+        params(
+          reference: Reference,
+          invalid_reference: T::Boolean,
+          checker: Checkers::Checker,
+        ).void
+      end
+      def collect_reference(reference, invalid_reference, checker)
+        if invalid_reference
+          @reference_collector.collect_invalid(reference: reference, violation_type: checker.violation_type)
+        else
+          @reference_collector.collect_valid(reference: reference, violation_type: checker.violation_type)
         end
       end
     end

--- a/lib/packwerk/reference_collector.rb
+++ b/lib/packwerk/reference_collector.rb
@@ -8,10 +8,7 @@ module Packwerk
 
     abstract!
 
-    sig { abstract.params(reference: Reference, violation_type: String).void }
-    def collect_invalid(reference:, violation_type:); end
-
-    sig { abstract.params(reference: Reference, violation_type: String).void }
-    def collect_valid(reference:, violation_type:); end
+    sig { abstract.params(reference: Reference, violation_type: String, valid: T::Boolean).void }
+    def collect_reference(reference:, violation_type:, valid:); end
   end
 end

--- a/lib/packwerk/reference_collector.rb
+++ b/lib/packwerk/reference_collector.rb
@@ -1,0 +1,17 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Packwerk
+  class ReferenceCollector
+    extend T::Sig
+    extend T::Helpers
+
+    abstract!
+
+    sig { abstract.params(reference: Reference, violation_type: String).void }
+    def collect_invalid(reference:, violation_type:); end
+
+    sig { abstract.params(reference: Reference, violation_type: String).void }
+    def collect_valid(reference:, violation_type:); end
+  end
+end

--- a/test/unit/reference_checking/reference_checker_test.rb
+++ b/test/unit/reference_checking/reference_checker_test.rb
@@ -29,6 +29,23 @@ module Packwerk
       end
     end
 
+    class StubCollector < ReferenceCollector
+      attr_reader :valid_count, :invalid_count
+
+      def initialize
+        @valid_count = 0
+        @invalid_count = 0
+      end
+
+      def collect_reference(reference:, violation_type:, valid:)
+        if valid
+          @valid_count += 1
+        else
+          @invalid_count += 1
+        end
+      end
+    end
+
     test "#call enumerates the list of checkers to create ReferenceOffense objects" do
       input_reference = build_reference
       message = ReferenceChecking::Checkers::PrivacyChecker.new.message(input_reference)
@@ -47,8 +64,25 @@ module Packwerk
       assert offense.message.start_with?("Privacy violation")
     end
 
-    def reference_checker(checkers = [StubChecker.new])
-      Packwerk::ReferenceChecking::ReferenceChecker.new(checkers)
+    test "#call passes the reference and it's validity to the ReferenceCollector" do
+      input_reference = build_reference
+      message = ReferenceChecking::Checkers::PrivacyChecker.new.message(input_reference)
+      collector = StubCollector.new
+      instance = reference_checker([StubChecker.new(
+          invalid_reference?: true,
+          message: message,
+          violation_type: ReferenceChecking::Checkers::PrivacyChecker::VIOLATION_TYPE
+        )],
+        collector
+      )
+      instance.call(input_reference)
+
+      assert_equal 1, collector.invalid_count
+      assert_equal 0, collector.valid_count
+    end
+
+    def reference_checker(checkers = [StubChecker.new], collector = StubCollector.new)
+      Packwerk::ReferenceChecking::ReferenceChecker.new(checkers, collector)
     end
   end
 end


### PR DESCRIPTION
A reference collector can be used for instrumenting `packwerk check`. The configured class,
extending Packwerk::ReferenceCollector, will be notified of each reference that the checkers
check, including whether it's valid or invalid. This can be useful for collecting metrics
over references.