### PR TITLE
feat: Add a stop method to ReferenceCollector

### DIFF
--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -109,6 +109,7 @@ module Packwerk
       end
 
       @progress_formatter.finished(execution_time)
+      run_context.stop_collector
 
       all_offenses.each { |offense| offense_collection.add_offense(offense) }
       offense_collection

--- a/lib/packwerk/reference_collector.rb
+++ b/lib/packwerk/reference_collector.rb
@@ -10,5 +10,8 @@ module Packwerk
 
     sig { abstract.params(reference: Reference, violation_type: String, valid: T::Boolean).void }
     def collect_reference(reference:, violation_type:, valid:); end
+
+    sig { overridable.void }
+    def stop; end
   end
 end

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -101,6 +101,11 @@ module Packwerk
       @package_set ||= ::Packwerk::PackageSet.load_all_from(@root_path, package_pathspec: @package_paths)
     end
 
+    sig { void }
+    def stop_collector
+      @reference_collector.stop
+    end
+
     private
 
     sig { returns(FileProcessor) }


### PR DESCRIPTION
## What are you trying to accomplish?

We need a way for packwerk to signal to the ReferenceCollector that it's done, so that the collector, in our target application, can then persist the metrics that it's collected.

