### PR TITLE
feat: add violation filter

### DIFF
--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -33,6 +33,7 @@ module Packwerk
   autoload :NodeProcessorFactory
   autoload :NodeVisitor
   autoload :NoOpReferenceCollector
+  autoload :NoOpViolationFilter
   autoload :Offense
   autoload :OffensesFormatter
   autoload :OutputStyle
@@ -49,6 +50,7 @@ module Packwerk
   autoload :Result
   autoload :RunContext
   autoload :Version
+  autoload :ViolationFilter
 
   module OutputStyles
     extend ActiveSupport::Autoload

--- a/lib/packwerk/no_op_violation_filter.rb
+++ b/lib/packwerk/no_op_violation_filter.rb
@@ -1,0 +1,13 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Packwerk
+  class NoOpViolationFilter < ViolationFilter
+    extend T::Sig
+
+    sig { override.params(reference: Reference).returns(T::Boolean) }
+    def ignore_violation?(reference)
+      false
+    end
+  end
+end

--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -65,7 +65,7 @@ module Packwerk
     sig { returns(Result) }
     def check
       run_context = Packwerk::RunContext.from_configuration(@configuration)
-      offense_collection = find_offenses(run_context, show_errors: true, collect_references: true)
+      offense_collection = find_offenses(run_context, show_errors: true, collect_references: true, filter_violations: true)
 
       messages = [
         @offenses_formatter.show_offenses(offense_collection.outstanding_offenses),
@@ -84,17 +84,18 @@ module Packwerk
       params(
         run_context: Packwerk::RunContext,
         show_errors: T::Boolean,
-        collect_references: T::Boolean
+        collect_references: T::Boolean,
+        filter_violations: T::Boolean
       ).returns(OffenseCollection)
     end
-    def find_offenses(run_context, show_errors: false, collect_references: false)
+    def find_offenses(run_context, show_errors: false, collect_references: false, filter_violations: false)
       offense_collection = OffenseCollection.new(@configuration.root_path)
       @progress_formatter.started(@relative_file_set)
 
       all_offenses = T.let([], T::Array[Offense])
 
       process_file = T.let(->(relative_file) do
-        run_context.process_file(relative_file: relative_file, collect_references: collect_references).tap do |offenses|
+        run_context.process_file(relative_file: relative_file, collect_references: collect_references, filter_violations: filter_violations).tap do |offenses|
           failed = show_errors && offenses.any? { |offense| !offense_collection.listed?(offense) }
           update_progress(failed: failed)
         end

--- a/lib/packwerk/reference_checking/reference_checker.rb
+++ b/lib/packwerk/reference_checking/reference_checker.rb
@@ -6,10 +6,21 @@ module Packwerk
     class ReferenceChecker
       extend T::Sig
 
-      sig { params(checkers: T::Array[Checkers::Checker], reference_collector: ReferenceCollector).void }
-      def initialize(checkers, reference_collector = NoOpReferenceCollector.new)
+      sig do
+        params(
+          checkers: T::Array[Checkers::Checker],
+          reference_collector: ReferenceCollector,
+          violation_filter: ViolationFilter,
+        ).void
+      end
+      def initialize(
+        checkers,
+        reference_collector = NoOpReferenceCollector.new,
+        violation_filter = NoOpViolationFilter.new
+      )
         @checkers = checkers
         @reference_collector = reference_collector
+        @violation_filter = violation_filter
       end
 
       sig do
@@ -27,6 +38,7 @@ module Packwerk
           )
 
           next unless invalid_reference
+          next if @violation_filter.ignore_violation?(reference)
 
           offense = Packwerk::ReferenceOffense.new(
             location: reference.source_location,

--- a/lib/packwerk/violation_filter.rb
+++ b/lib/packwerk/violation_filter.rb
@@ -1,0 +1,16 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Optionally do not consider offenses as violations.
+module Packwerk
+  class ViolationFilter
+    extend T::Sig
+    extend T::Helpers
+
+    abstract!
+
+    sig { abstract.params(reference: Reference).returns(T::Boolean) }
+    def ignore_violation?(reference)
+    end
+  end
+end


### PR DESCRIPTION
## What are you trying to accomplish?
We have a `packwerk check || true` step that checks for violations, and reports metrics. we have `|| true` because we don't want this job to block prs when there are new violations. We update the todo files daily, so that they reflect the state of the code base.

We want to make it harder to introduce new boundary violations, but not get so much in the way of people doing their product work - 
* we could take away the `|| true` and make people run `packwerk update-todo` on their own when they introduce new violations. simple, but all-or-nothing & potentially more annoying than helpful
* in a script, read the output of `packwerk check`, check violations against package configs, and decide whether to exit with 1 or 0
* (this pr) instead of post-processing the results, add the ability to insert a custom filter that can decide whether to consider an offense during `packwerk check`. follows a similar pattern to reference collector 

## What approach did you choose and why?
* building scripts on top of `packwerk check` output sounds brittle, and inserting a custom output formatter doesn't feel like it would make it that much better (although newer commits to shopify/packwerk make it easier to pass a custom formatter...)
* this approach has us drifting farther away from the main library, but i think our usage is already drifting - we mainly use this for privacy as opposed to dependency tracking and that functionality has been [moved out](https://github.com/Shopify/packwerk/blob/main/UPGRADING.md#removal-of-privacy-checking) of the main gem. 
* this allows individual packages to decide if they care about new violations or not. if someone needs to add a boundary violation in that package they can still do it by running `update-todo`
* example usage at https://github.com/scriptdash/scriptdash/pull/38584/files 

## What should reviewers focus on?


## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] It is safe to rollback this change.
