### PR TITLE
fix: ignore stale violations for check success

### DIFF
--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -75,7 +75,7 @@ module Packwerk
 
       blocking_offenses = false
       if offense_collection.outstanding_offenses.present?
-        messages << "[ACTION REQUIRED] Fix the following, or run packwerk update-todo:"
+        messages << "[ERROR] Fix the following, or run packwerk update-todo:"
         messages << @offenses_formatter.show_offenses(offense_collection.outstanding_offenses)
         blocking_offenses = true
       end


### PR DESCRIPTION
## What are you trying to accomplish?

If there are stale violations (listed in package_todo but not actually a violation anymore), we don't want that to fail `packwerk check` - we don't want to create work for people when they remove boundary violations. We won't have a problem of building up stale entries since we are running `packwerk update-todo` nightly

also slightly updating the messaging to make it clearer what's a relaxed violation vs one that needs action, because i was confused earlier and thought we were somehow using an older version of the code because the output looked the same 

## What approach did you choose and why?


## What should reviewers focus on?


## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] It is safe to rollback this change.
